### PR TITLE
#107, #170 fix unhandled timeouts and other errors for polling

### DIFF
--- a/src/telegram.js
+++ b/src/telegram.js
@@ -529,10 +529,11 @@ class TelegramBot extends EventEmitter {
    * @return {Promise}
    * @see https://core.telegram.org/bots/api#answercallbackquery
    */
-  answerCallbackQuery(callbackQueryId, text, showAlert, form = {}) {
+  answerCallbackQuery(callbackQueryId, text, showAlert, url, form = {}) {
     form.callback_query_id = callbackQueryId;
     form.text = text;
     form.show_alert = showAlert;
+	form.url = url;
     return this._request('answerCallbackQuery', { form });
   }
 

--- a/src/telegramPolling.js
+++ b/src/telegramPolling.js
@@ -125,7 +125,10 @@ class TelegramBotPolling {
         }
 
         throw new Error(`${data.error_code} ${data.description}`);
-      });
+      })
+	  .catch(err => {
+		  throw new Error(`Unhandled error on _getUpdates: ${err}`);
+	  });
   }
 
 }


### PR DESCRIPTION
Sometimes i find Unhandled rejection TimeoutError: operation timed out exception after this bot not working without restart. I catch unhandled request errors and raise exception to you code.

---

Original-PR: https://github.com/yagop/node-telegram-bot-api/pull/180
Author: revkov

---

/ghupfork by Forfuture LLC (http://medusa.forfuture.co.ke)
