### PR TITLE
Proxy extra request options

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "bluebird": "^3.3.4",
     "debug": "^2.2.0",
     "eventemitter3": "^1.2.0",
+    "extend": "^3.0.0",
     "file-type": "^3.8.0",
     "mime": "^1.3.4",
     "pump": "^1.0.1",

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -13,6 +13,7 @@ const path = require('path');
 const URL = require('url');
 const fs = require('fs');
 const pump = require('pump');
+const extend = require('extend');
 
 const _messageTypes = [
   'text', 'audio', 'document', 'photo', 'sticker', 'video', 'voice', 'contact',
@@ -41,6 +42,7 @@ class TelegramBot extends EventEmitter {
    * @param {Boolean|Object} [options.webHook=false] Set true to enable WebHook or set options
    * @param {String} [options.webHook.key] PEM private key to webHook server.
    * @param {String} [options.webHook.cert] PEM certificate (public) to webHook server.
+   * @param {Object} [options.request] Options which will be added for all requests to telegram api.
    * @see https://core.telegram.org/bots/api
    */
   constructor(token, options = {}) {
@@ -145,6 +147,10 @@ class TelegramBot extends EventEmitter {
   _request(_path, options = {}) {
     if (!this.token) {
       throw new Error('Telegram Bot Token not provided!');
+    }
+
+    if (this.options.request) {
+      extend(true, options, this.options.request);
     }
 
     if (options.form) {


### PR DESCRIPTION
I have a server which has only ipv6 access to api.telegram.org. So, I must pass `family: 6` option for each request to telegram api.

It would be great to add an extra option to TelegramBot constructor which makes it possible.

@yagop what do you think?

---

Original-PR: https://github.com/yagop/node-telegram-bot-api/pull/178
Author: tarmolov

---

/ghupfork by Forfuture LLC (http://medusa.forfuture.co.ke)
