### PR TITLE
JSON-stringify reply_markup when it is sent in qs

### DIFF
--- a/src/telegram.js
+++ b/src/telegram.js
@@ -121,6 +121,14 @@ class TelegramBot extends EventEmitter {
       throw new Error(`Error parsing Telegram response: ${String(json)}`);
     }
   }
+  
+  _fixReplyMarkup(obj) {
+    const replyMarkup = obj.reply_markup;
+    if (replyMarkup && typeof replyMarkup !== 'string') {
+      // reply_markup must be passed as JSON stringified to Telegram
+      obj.reply_markup = JSON.stringify(replyMarkup);
+    }
+  }
 
   // request-promise
   _request(_path, options = {}) {
@@ -129,11 +137,10 @@ class TelegramBot extends EventEmitter {
     }
 
     if (options.form) {
-      const replyMarkup = options.form.reply_markup;
-      if (replyMarkup && typeof replyMarkup !== 'string') {
-        // reply_markup must be passed as JSON stringified to Telegram
-        options.form.reply_markup = JSON.stringify(replyMarkup);
-      }
+      this._fixReplyMarkup(options.form);
+    }
+    if (options.qs) {
+      this._fixReplyMarkup(options.qs);
     }
     options.url = this._buildURL(_path);
     options.simple = false;


### PR DESCRIPTION
Currently, `reply_markup` is only JSON-stringified when sent in form (e.g. in `sendMessage`). However, `sendPhoto` tries to send it in query string. I've fixed this.

---

Original-PR: https://github.com/yagop/node-telegram-bot-api/pull/133
Author: m-burst

---

/ghupfork by Forfuture LLC (http://medusa.forfuture.co.ke)
