### PR TITLE
Update telegramWebHook.js pass `ca` prop to https.createServer options

### DIFF
--- a/src/telegramWebHook.js
+++ b/src/telegramWebHook.js
@@ -16,6 +16,7 @@ var TelegramBotWebHook = function (token, options, callback) {
   if (options.key && options.cert) { // HTTPS Server
     debug('HTTPS WebHook enabled');
     var opts = {
+      ca: options.ca
       key: fs.readFileSync(options.key),
       cert: fs.readFileSync(options.cert)
     };


### PR DESCRIPTION
To use PositiveSSL by Comodo you need to pass `ca` property to https.createServer options.

http://www.benjiegillam.com/2012/06/node-dot-js-ssl-certificate-chain/

Use it like so:

```
var bot = new TelegramBot(token,
    {
      webHook: {
        ca: [
          fs.readFileSync('./COMODORSADomainValidationSecureServerCA.crt'),
          fs.readFileSync('./COMODORSAAddTrustCA.crt')
        ],
        key: './domain.com.key',
        cert: './domain.com.crt'
      },
      host: 'https://domain.com',
      port: '8443'
    }
  );

---

Original-PR: https://github.com/yagop/node-telegram-bot-api/pull/17
Author: yangit

---

/ghupfork by Forfuture LLC (http://medusa.forfuture.co.ke)
```
