### PR TITLE
Implement 'leaveChat'

### DIFF
--- a/src/telegram.js
+++ b/src/telegram.js
@@ -711,6 +711,19 @@ class TelegramBot extends EventEmitter {
       callback
     });
   }
+
+  /**
+   * Leave a group, supergroup or channel.
+   * @param  {Number|String}   chatId       Unique identifier for the target group or username of the target supergroup (in the format @supergroupusername)
+   * @return {Promise}
+   * @see https://core.telegram.org/bots/api#leavechat
+   */
+  leaveChat(chatId) {
+    const form = {
+      chat_id: chatId
+    };
+    return this._request('leaveChat', { form });
+  }
 }
 
 module.exports = TelegramBot;


### PR DESCRIPTION
API Method [leaveChat](https://core.telegram.org/bots/api#leavechat): https://core.telegram.org/bots/api#leavechat

---

Original-PR: https://github.com/yagop/node-telegram-bot-api/pull/186
Author: GochoMugo

---

/ghupfork by Forfuture LLC (http://medusa.forfuture.co.ke)
